### PR TITLE
feat: scaffold Astro site with Tailwind and image integration

### DIFF
--- a/limitedcharm-site/.gitignore
+++ b/limitedcharm-site/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/limitedcharm-site/README.md
+++ b/limitedcharm-site/README.md
@@ -1,0 +1,24 @@
+# limitedcharm-site
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## Preview
+
+```bash
+npm run preview
+```
+
+## Deployment
+
+Deploy the contents of the `dist/` directory to your static hosting provider.

--- a/limitedcharm-site/astro.config.mjs
+++ b/limitedcharm-site/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+import image from '@astrojs/image';
+
+export default defineConfig({
+  site: 'https://example.com',
+  integrations: [tailwind(), image()],
+});

--- a/limitedcharm-site/package.json
+++ b/limitedcharm-site/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "limitedcharm-site",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0",
+    "@astrojs/image": "^0.17.0"
+  },
+  "devDependencies": {
+    "@astrojs/tailwind": "^5.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/limitedcharm-site/postcss.config.cjs
+++ b/limitedcharm-site/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/limitedcharm-site/src/pages/index.astro
+++ b/limitedcharm-site/src/pages/index.astro
@@ -1,0 +1,13 @@
+---
+import '../styles/tailwind.css';
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>limitedcharm-site</title>
+  </head>
+  <body>
+    <h1 class="text-3xl font-bold">Welcome to limitedcharm-site</h1>
+  </body>
+</html>

--- a/limitedcharm-site/src/styles/tailwind.css
+++ b/limitedcharm-site/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/limitedcharm-site/tailwind.config.js
+++ b/limitedcharm-site/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./src/**/*.{astro,md,mdx,ts,tsx,js}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/limitedcharm-site/tsconfig.json
+++ b/limitedcharm-site/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
## Summary
- Scaffold `limitedcharm-site` using Astro basics template structure
- Configure Tailwind, Astro Image, and project metadata
- Add development, build, and preview scripts with basic README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@astrojs%2fimage)*
- `npm run dev` *(fails: astro: not found)*
- `npm run build` *(fails: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddc9bd6688330890e2e4d472f6ae4