### PR TITLE
feat: add accessible header footer and i18n

### DIFF
--- a/limitedcharm-site/src/assets/logo.svg
+++ b/limitedcharm-site/src/assets/logo.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
-  <text x="0" y="15" font-size="15">Logo</text>
-</svg>

--- a/limitedcharm-site/src/assets/svg.md
+++ b/limitedcharm-site/src/assets/svg.md
@@ -1,0 +1,19 @@
+# SVG Placeholders
+
+## Logo
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <text x="0" y="15" font-size="15">Logo</text>
+</svg>
+```
+
+## Hamburger Menu
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2">
+  <line x1="3" y1="6" x2="21" y2="6" />
+  <line x1="3" y1="12" x2="21" y2="12" />
+  <line x1="3" y1="18" x2="21" y2="18" />
+</svg>
+```

--- a/limitedcharm-site/src/components/Footer.astro
+++ b/limitedcharm-site/src/components/Footer.astro
@@ -3,16 +3,34 @@ import { getDictionary } from '../i18n/dict';
 import type { Lang } from '../i18n/config';
 
 interface Props { lang: Lang; }
-const { legal } = getDictionary(Astro.props.lang);
+const lang = Astro.props.lang;
+const { legal } = getDictionary(lang);
 ---
-<footer class="p-4">
-  <nav>
-    <ul class="flex gap-4">
-      <li><a href={`/${Astro.props.lang}/privacy`}>{legal.privacy}</a></li>
-      <li><a href={`/${Astro.props.lang}/terms`}>{legal.terms}</a></li>
-      <li><a href={`/${Astro.props.lang}/shipping`}>{legal.shipping}</a></li>
-      <li><a href={`/${Astro.props.lang}/disclaimer`}>{legal.disclaimer}</a></li>
-      <li><a href={`/${Astro.props.lang}/complaint`}>{legal.complaint}</a></li>
-    </ul>
-  </nav>
+<footer class="border-t mt-8">
+  <div class="mx-auto max-w-screen-xl p-4">
+    <div class="mb-4">
+      <address class="not-italic">
+        123 Example St<br />
+        Skopje, MK<br />
+        <a href="tel:+1234567890" class="block min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">+1 234 567 890</a>
+        <a href="mailto:info@example.com" class="block min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">info@example.com</a>
+      </address>
+    </div>
+    <nav aria-label="Legal">
+      <ul class="mb-4 flex flex-wrap gap-4">
+        <li><a href={`/${lang}/privacy`} class="block px-2 py-1 min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">{legal.privacy}</a></li>
+        <li><a href={`/${lang}/terms`} class="block px-2 py-1 min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">{legal.terms}</a></li>
+        <li><a href={`/${lang}/shipping`} class="block px-2 py-1 min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">{legal.shipping}</a></li>
+        <li><a href={`/${lang}/disclaimer`} class="block px-2 py-1 min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">{legal.disclaimer}</a></li>
+        <li><a href={`/${lang}/complaint`} class="block px-2 py-1 min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">{legal.complaint}</a></li>
+      </ul>
+    </nav>
+    <div>
+      <ul class="flex gap-4">
+        <li><a href="#" class="block px-2 py-1 min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">Facebook</a></li>
+        <li><a href="#" class="block px-2 py-1 min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">Twitter</a></li>
+        <li><a href="#" class="block px-2 py-1 min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">Instagram</a></li>
+      </ul>
+    </div>
+  </div>
 </footer>

--- a/limitedcharm-site/src/components/Header.astro
+++ b/limitedcharm-site/src/components/Header.astro
@@ -1,18 +1,61 @@
 ---
 import { getDictionary } from '../i18n/dict';
+import { SUPPORTED_LANGUAGES } from '../i18n/config';
 import type { Lang } from '../i18n/config';
 
 interface Props { lang: Lang; }
-const { nav } = getDictionary(Astro.props.lang);
+const lang = Astro.props.lang;
+const { nav } = getDictionary(lang);
+const path = Astro.url.pathname;
+const suffix = path.replace(new RegExp(`^/${lang}`), '') || '/';
 ---
-<header class="p-4">
-  <nav>
-    <ul class="flex gap-4">
-      <li><a href={`/${Astro.props.lang}/`}>{nav.home}</a></li>
-      <li><a href={`/${Astro.props.lang}/products`}>{nav.products}</a></li>
-      <li><a href={`/${Astro.props.lang}/about`}>{nav.about}</a></li>
-      <li><a href={`/${Astro.props.lang}/faq`}>{nav.faq}</a></li>
-      <li><a href={`/${Astro.props.lang}/contact`}>{nav.contact}</a></li>
-    </ul>
-  </nav>
+<header class="border-b">
+  <div class="mx-auto flex max-w-screen-xl items-center justify-between p-4">
+    <a href={`/${lang}/`} class="min-w-[44px] min-h-[44px] flex items-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" aria-label="Home">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20" class="h-5 w-auto">
+        <text x="0" y="15" font-size="15">Logo</text>
+      </svg>
+    </a>
+
+    <nav class="hidden md:block" aria-label="Primary">
+      <ul class="flex gap-4">
+        <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/`}>{nav.home}</a></li>
+        <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/products`}>{nav.products}</a></li>
+        <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/about`}>{nav.about}</a></li>
+        <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/faq`}>{nav.faq}</a></li>
+        <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/contact`}>{nav.contact}</a></li>
+      </ul>
+    </nav>
+
+    <div class="hidden md:flex gap-2" aria-label="Language switcher">
+      {SUPPORTED_LANGUAGES.map((l) => (
+        <a href={`/${l}${suffix}`} class="block px-2 py-2 min-w-[44px] min-h-[44px] flex items-center justify-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">{l.toUpperCase()}</a>
+      ))}
+    </div>
+
+    <details class="md:hidden">
+      <summary class="list-none cursor-pointer min-w-[44px] min-h-[44px] flex items-center justify-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2" class="h-6 w-6">
+          <line x1="3" y1="6" x2="21" y2="6" />
+          <line x1="3" y1="12" x2="21" y2="12" />
+          <line x1="3" y1="18" x2="21" y2="18" />
+        </svg>
+        <span class="sr-only">Menu</span>
+      </summary>
+      <nav class="mt-2" aria-label="Mobile primary">
+        <ul class="flex flex-col gap-2">
+          <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/`}>{nav.home}</a></li>
+          <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/products`}>{nav.products}</a></li>
+          <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/about`}>{nav.about}</a></li>
+          <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/faq`}>{nav.faq}</a></li>
+          <li><a class="block px-3 py-2 min-w-[44px] min-h-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" href={`/${lang}/contact`}>{nav.contact}</a></li>
+        </ul>
+        <div class="mt-2 flex gap-2" aria-label="Language switcher">
+          {SUPPORTED_LANGUAGES.map((l) => (
+            <a href={`/${l}${suffix}`} class="block px-2 py-2 min-w-[44px] min-h-[44px] flex items-center justify-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">{l.toUpperCase()}</a>
+          ))}
+        </div>
+      </nav>
+    </details>
+  </div>
 </header>

--- a/limitedcharm-site/src/layouts/BaseLayout.astro
+++ b/limitedcharm-site/src/layouts/BaseLayout.astro
@@ -1,41 +1,37 @@
-import type { Lang } from './config';
+---
+import '../styles/tailwind.css';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import type { Lang } from '../i18n/config';
+import { SUPPORTED_LANGUAGES, DEFAULT_LANG } from '../i18n/config';
 
-export type SectionDict = {
-  nav: { home: string; products: string; about: string; faq: string; contact: string; legal: string };
-  hero: { title: string; subtitle: string };
-  about: { heading: string };
-  faq: { heading: string };
-  contact: { heading: string };
-  legal: { privacy: string; terms: string; shipping: string; disclaimer: string; complaint: string };
-};
-
-export const dictionaries: Record<Lang, SectionDict> = {
-  mk: {
-    nav: { home: 'Почетна', products: 'Производи', about: 'За нас', faq: 'ЧПП', contact: 'Контакт', legal: 'Правни' },
-    hero: { title: 'Добредојдовте', subtitle: 'Празен херој' },
-    about: { heading: 'За нас' },
-    faq: { heading: 'ЧПП' },
-    contact: { heading: 'Контакт' },
-    legal: { privacy: 'Приватност', terms: 'Услови', shipping: 'Испорака', disclaimer: 'Одговорност', complaint: 'Претставка' }
-  },
-  en: {
-    nav: { home: 'Home', products: 'Products', about: 'About', faq: 'FAQ', contact: 'Contact', legal: 'Legal' },
-    hero: { title: 'Welcome', subtitle: 'Simple hero' },
-    about: { heading: 'About Us' },
-    faq: { heading: 'FAQ' },
-    contact: { heading: 'Contact' },
-    legal: { privacy: 'Privacy', terms: 'Terms', shipping: 'Shipping', disclaimer: 'Disclaimer', complaint: 'Complaint' }
-  },
-  sq: {
-    nav: { home: 'Ballina', products: 'Produkte', about: 'Rreth nesh', faq: 'FAQ', contact: 'Kontakt', legal: 'Ligjore' },
-    hero: { title: 'Mirë se vini', subtitle: 'Hero i thjeshtë' },
-    about: { heading: 'Rreth Nesh' },
-    faq: { heading: 'FAQ' },
-    contact: { heading: 'Kontakt' },
-    legal: { privacy: 'Privatësia', terms: 'Kushtet', shipping: 'Dërgesa', disclaimer: 'Përgënjeshtrim', complaint: 'Ankesë' }
-  }
-};
-
-export function getDictionary(lang: Lang): SectionDict {
-  return dictionaries[lang];
+interface Props {
+  lang: Lang;
+  title: string;
+  description?: string;
 }
+
+const { lang, title, description } = Astro.props;
+const path = Astro.url.pathname;
+const suffix = path.replace(new RegExp(`^/${lang}`), '') || '/';
+---
+<!DOCTYPE html>
+<html lang={lang}>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    {SUPPORTED_LANGUAGES.map((l) => (
+      <link rel="alternate" hreflang={l} href={`/${l}${suffix}`} />
+    ))}
+    <link rel="alternate" hreflang="x-default" href={`/${DEFAULT_LANG}${suffix}`} />
+  </head>
+  <body class="min-h-screen flex flex-col">
+    <Header lang={lang} />
+    <main class="flex-1">
+      <slot />
+    </main>
+    <Footer lang={lang} />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement responsive header with mobile menu and language switcher
- add footer with contact info, legal links, and social placeholders
- create base layout with hreflang alternate links and document SVG assets in markdown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: astro: not found)*
- `npm install --force` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689dec29c35083309440cf2003bd5a9e