### PR TITLE
Clean up duplicate content and fix product pages

### DIFF
--- a/limitedcharm-site/package-lock.json
+++ b/limitedcharm-site/package-lock.json
@@ -8,7 +8,6 @@
       "name": "limitedcharm-site",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/image": "^0.16.8",
         "astro": "^5.13.0"
       },
       "devDependencies": {
@@ -42,42 +41,6 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.2.tgz",
       "integrity": "sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==",
       "license": "MIT"
-    },
-    "node_modules/@astrojs/image": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/image/-/image-0.16.8.tgz",
-      "integrity": "sha512-ka18Y8HXllitE4TN66tmxqc1j+pgfqfq5i/D3I0QmmH2hFd7olFNVDrd15S4ZM1U5jxZORUv+PuJU0g8dZEjqQ==",
-      "deprecated": "@astrojs/image is deprecated in favor of astro:assets. Please see the migration guide for more information: https://docs.astro.build/en/guides/upgrade-to/v3/\\#removed-astrojsimage",
-      "license": "MIT",
-      "dependencies": {
-        "@altano/tiny-async-pool": "^1.0.2",
-        "http-cache-semantics": "^4.1.0",
-        "image-size": "^1.0.2",
-        "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
-        "mime": "^3.0.0"
-      },
-      "peerDependencies": {
-        "astro": "^2.4.5",
-        "sharp": ">=0.31.0"
-      },
-      "peerDependenciesMeta": {
-        "sharp": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@astrojs/image/node_modules/magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.7.1",

--- a/limitedcharm-site/package.json
+++ b/limitedcharm-site/package.json
@@ -9,7 +9,6 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "@astrojs/image": "^0.16.8",
     "astro": "^5.13.0"
   },
   "devDependencies": {

--- a/limitedcharm-site/src/components/Hero.astro
+++ b/limitedcharm-site/src/components/Hero.astro
@@ -1,25 +1,20 @@
 ---
 import { getDictionary } from '../i18n/dict';
 import type { Lang } from '../i18n/config';
-import { Image } from '@astrojs/image/components';
+// Using standard img tags for hero images
 
 interface Props {
   lang: Lang;
   image?: string;
 }
 
-interface Props { lang: Lang; }
 const { hero } = getDictionary(Astro.props.lang);
 const image = Astro.props.image;
 ---
-<section class="p-8 text-center">
-  <h1 class="text-3xl font-bold">{hero.title}</h1>
-  <p>{hero.subtitle}</p>
-</section>
 <section class="py-12 text-center">
   <div class="flex flex-col items-center gap-6">
     {image && (
-      <Image src={image} alt={hero.title} width={960} height={400} formats={['avif','webp','png']} sizes="(max-width: 768px) 100vw, 960px" loading="lazy" />
+      <img src={image} alt={hero.title} width="960" height="400" loading="lazy" class="rounded" />
     )}
     <h1 class="text-4xl font-bold">{hero.title}</h1>
     <p class="max-w-2xl text-lg">{hero.subtitle}</p>

--- a/limitedcharm-site/src/components/ProductCard.astro
+++ b/limitedcharm-site/src/components/ProductCard.astro
@@ -1,30 +1,23 @@
 ---
-import { Image } from '@astrojs/image/components';
 import type { Lang } from '../i18n/config';
 
 interface Props {
   title: string;
-  description: string;
-  image?: string;
+  description?: string;
+  image: string;
   short: string;
   price: string;
   price_old?: string;
-  image: string;
   slug: string;
   lang: Lang;
 }
-const { title, description, image } = Astro.props;
 
-const { title, short, price, price_old, image, slug, lang } = Astro.props;
+const { title, description, image, short, price, price_old, slug, lang } = Astro.props;
 ---
-<article class="p-4 border">
-  {image && <img src={image} alt={title} class="mb-2" />}
-  <h3 class="font-semibold">{title}</h3>
-  <p>{description}</p>
-</article>
 <article class="border p-4 flex flex-col">
-  <Image src={image} alt={title} width={300} height={300} formats={['avif','webp','png']} loading="lazy" class="mb-4 rounded" />
+  <img src={image} alt={title} width="300" height="300" loading="lazy" class="mb-4 rounded" />
   <h3 class="text-xl font-semibold mb-2">{title}</h3>
+  {description && <p class="mb-2">{description}</p>}
   <p class="mb-4">{short}</p>
   <div class="mt-auto">
     <p class="text-lg font-bold">

--- a/limitedcharm-site/src/components/Stats.astro
+++ b/limitedcharm-site/src/components/Stats.astro
@@ -4,17 +4,13 @@ interface Props {
 }
 const { stats } = Astro.props;
 ---
-<section>
-  <ul class="flex gap-4">
 <section class="py-12 bg-gray-100">
   <ul class="max-w-4xl mx-auto grid grid-cols-1 sm:grid-cols-3 gap-8 text-center">
     {stats.map((s) => (
       <li>
-        <p class="text-2xl">{s.value}</p>
         <p class="text-3xl font-bold">{s.value}</p>
         <p>{s.label}</p>
       </li>
     ))}
   </ul>
-</section>
 </section>

--- a/limitedcharm-site/src/content/products/product-1.mdx
+++ b/limitedcharm-site/src/content/products/product-1.mdx
@@ -1,8 +1,6 @@
 ---
-title: "Product 1"
-description: "First product"
-image: "../assets/placeholder.png"
 title: "Herbal Supplement"
+description: "First product"
 subtitle: "Daily health support"
 price: "25 €"
 price_old: "30 €"

--- a/limitedcharm-site/src/content/products/product-2.mdx
+++ b/limitedcharm-site/src/content/products/product-2.mdx
@@ -1,8 +1,6 @@
 ---
-title: "Product 2"
-description: "Second product"
-image: "../assets/placeholder.png"
 title: "Natural Cream"
+description: "Second product"
 subtitle: "Soothing skin care"
 price: "18 €"
 image: "../../assets/product2.png"

--- a/limitedcharm-site/src/i18n/dict.ts
+++ b/limitedcharm-site/src/i18n/dict.ts
@@ -2,8 +2,6 @@ import type { Lang } from './config';
 
 export type SectionDict = {
   nav: { home: string; products: string; about: string; faq: string; contact: string; legal: string };
-  hero: { title: string; subtitle: string };
-  about: { heading: string };
   hero: { title: string; subtitle: string; cta: string };
   about: { heading: string; benefits: string[] };
   stats: { years: string; orders: string; satisfaction: string };
@@ -15,8 +13,6 @@ export type SectionDict = {
 export const dictionaries: Record<Lang, SectionDict> = {
   mk: {
     nav: { home: 'Почетна', products: 'Производи', about: 'За нас', faq: 'ЧПП', contact: 'Контакт', legal: 'Правни' },
-    hero: { title: 'Добредојдовте', subtitle: 'Празен херој' },
-    about: { heading: 'За нас' },
     hero: {
       title: 'Природни додатоци и креми',
       subtitle: 'Подобрете го вашето здравје со нашите додатоци во исхраната и природни креми.',
@@ -33,8 +29,6 @@ export const dictionaries: Record<Lang, SectionDict> = {
   },
   en: {
     nav: { home: 'Home', products: 'Products', about: 'About', faq: 'FAQ', contact: 'Contact', legal: 'Legal' },
-    hero: { title: 'Welcome', subtitle: 'Simple hero' },
-    about: { heading: 'About Us' },
     hero: {
       title: 'Natural Supplements & Creams',
       subtitle: 'Enhance your wellbeing with our dietary supplements and natural creams crafted from quality ingredients.',
@@ -51,8 +45,6 @@ export const dictionaries: Record<Lang, SectionDict> = {
   },
   sq: {
     nav: { home: 'Ballina', products: 'Produkte', about: 'Rreth nesh', faq: 'FAQ', contact: 'Kontakt', legal: 'Ligjore' },
-    hero: { title: 'Mirë se vini', subtitle: 'Hero i thjeshtë' },
-    about: { heading: 'Rreth Nesh' },
     hero: {
       title: 'Suplementet dhe Kremrat Natyral',
       subtitle: 'Përmirësoni mirëqenien me suplementet ushqimore dhe kremrat natyral të përzgjedhur me kujdes.',

--- a/limitedcharm-site/src/pages/[lang]/index.astro
+++ b/limitedcharm-site/src/pages/[lang]/index.astro
@@ -27,7 +27,6 @@ const stats = [
 ];
 ---
 <BaseLayout lang={lang} title="Home" description="">
-</BaseLayout>
   <Hero lang={lang} />
   <section class="py-12">
     <div class="max-w-4xl mx-auto text-center">

--- a/limitedcharm-site/src/pages/[lang]/products/[slug]/index.astro
+++ b/limitedcharm-site/src/pages/[lang]/products/[slug]/index.astro
@@ -1,49 +1,38 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import Hero from '../../components/Hero.astro';
-import ProductCard from '../../components/ProductCard.astro';
-import Stats from '../../components/Stats.astro';
-import { getDictionary } from '../../i18n/dict';
-import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
-import product1 from '../../content/products/product-1.mdx';
-import product2 from '../../content/products/product-2.mdx';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../../i18n/config';
+import product1 from '../../../content/products/product-1.mdx';
+import product2 from '../../../content/products/product-2.mdx';
+
+const allProducts = [product1, product2];
 
 export function getStaticPaths() {
-  return SUPPORTED_LANGUAGES.map((lang) => ({ params: { lang } }));
+  const paths = [];
+  for (const prod of allProducts) {
+    for (const lang of SUPPORTED_LANGUAGES) {
+      paths.push({
+        params: { lang, slug: prod.frontmatter.slug },
+        props: { product: prod.frontmatter, Content: prod.default }
+      });
+    }
+  }
+  return paths;
 }
 
 const { lang } = Astro.params;
-
 if (!isLang(lang)) {
   throw Astro.redirect(`/${DEFAULT_LANG}/`);
 }
 
-const dict = getDictionary(lang);
-const products = [product1.frontmatter, product2.frontmatter];
-const stats = [
-  { label: dict.stats.years, value: '5+' },
-  { label: dict.stats.orders, value: '1500+' },
-  { label: dict.stats.satisfaction, value: '98%' }
-];
+const { product, Content } = Astro.props;
 ---
-<BaseLayout lang={lang} title="Home" description="">
+<BaseLayout lang={lang} title={product.title} description={product.description}>
+  <article class="max-w-3xl mx-auto py-12">
+    <img src={product.image} alt={product.title} width="600" height="600" class="mb-4 rounded" />
+    <h1 class="text-3xl font-bold mb-4">{product.title}</h1>
+    <p class="mb-4">{product.short}</p>
+    {/** Render MDX content */}
+    <Content />
+  </article>
 </BaseLayout>
-  <Hero lang={lang} />
-  <section class="py-12">
-    <div class="max-w-4xl mx-auto text-center">
-      <h2 class="text-2xl font-bold mb-6">{dict.about.heading}</h2>
-      <ul class="max-w-md mx-auto list-disc list-inside space-y-2 text-left">
-        {dict.about.benefits.map((b) => <li>{b}</li>)}
-      </ul>
-    </div>
-  </section>
-  <section class="py-12">
-    <h2 class="text-2xl text-center font-bold mb-6">{dict.nav.products}</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
-      {products.map((p) => (
-        <ProductCard lang={lang} {...p} />
-      ))}
-    </div>
-  </section>
-  <Stats stats={stats} />
-</BaseLayout>
+


### PR DESCRIPTION
## Summary
- dedupe i18n dictionary and streamline component props
- simplify hero, product card, and stats sections
- fix home/product pages and clean product metadata

## Testing
- `npm view astro version` *(fails: 403 Forbidden)*
- `npm run build` *(fails: astro not found, dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689e01caf5208330b36c94abe6d0d2e9