### PR TITLE
Add homepage hero, products, and stats sections

### DIFF
--- a/limitedcharm-site/src/components/Hero.astro
+++ b/limitedcharm-site/src/components/Hero.astro
@@ -6,18 +6,22 @@ import { Image } from '@astrojs/image/components';
 interface Props {
   lang: Lang;
   image?: string;
+  ctaHref?: string;
 }
 
 const { hero } = getDictionary(Astro.props.lang);
-const image = Astro.props.image;
+const { image, ctaHref } = Astro.props;
+const href = ctaHref ?? `/${Astro.props.lang}/products`;
 ---
-<section class="py-12 text-center">
-  <div class="flex flex-col items-center gap-6">
+<section class="py-12">
+  <div class="max-w-5xl mx-auto flex flex-col md:flex-row items-center gap-8">
     {image && (
-      <Image src={image} alt={hero.title} width={960} height={400} formats={["avif", "webp", "png"]} sizes="(max-width: 768px) 100vw, 960px" loading="lazy" class="rounded" />
+      <Image src={image} alt={hero.title} width={960} height={400} formats={["avif", "webp", "png"]} sizes="(max-width: 768px) 100vw, 960px" loading="lazy" class="rounded w-full md:w-1/2" />
     )}
-    <h1 class="text-4xl font-bold">{hero.title}</h1>
-    <p class="max-w-2xl text-lg">{hero.subtitle}</p>
-    <a href={`/${Astro.props.lang}/products`} class="mt-4 px-6 py-3 bg-blue-600 text-white rounded">{hero.cta}</a>
+    <div class="text-center md:text-left md:w-1/2 flex flex-col items-center md:items-start">
+      <h1 class="text-4xl font-bold mb-4">{hero.title}</h1>
+      <p class="max-w-xl mb-6 text-lg">{hero.subtitle}</p>
+      <a href={href} class="px-6 py-3 bg-blue-600 text-white rounded">{hero.cta}</a>
+    </div>
   </div>
 </section>

--- a/limitedcharm-site/src/pages/[lang]/index.astro
+++ b/limitedcharm-site/src/pages/[lang]/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Hero from '../../components/Hero.astro';
 import ProductCard from '../../components/ProductCard.astro';
 import Stats from '../../components/Stats.astro';
+import ContactBlock from '../../components/ContactBlock.astro';
 import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 import product1 from '../../content/products/product-1.mdx';
@@ -28,7 +29,8 @@ const stats = [
 const heroImage = 'https://via.placeholder.com/960x400';
 ---
 <BaseLayout lang={lang} title="Home" description="">
-  <Hero lang={lang} image={heroImage} />
+  <Hero lang={lang} image={heroImage} ctaHref="#products" />
+
   <section class="py-12">
     <div class="max-w-4xl mx-auto text-center">
       <h2 class="text-2xl font-bold mb-6">{dict.about.heading}</h2>
@@ -37,7 +39,8 @@ const heroImage = 'https://via.placeholder.com/960x400';
       </ul>
     </div>
   </section>
-  <section class="py-12">
+
+  <section id="products" class="py-12">
     <h2 class="text-2xl text-center font-bold mb-6">{dict.nav.products}</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
       {products.map((p) => (
@@ -45,5 +48,10 @@ const heroImage = 'https://via.placeholder.com/960x400';
       ))}
     </div>
   </section>
+
   <Stats stats={stats} />
+
+  <section id="contact" class="py-12">
+    <ContactBlock lang={lang} />
+  </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Build responsive hero with configurable CTA for products anchor
- Render about benefits, featured products, stats, and contact blocks on localized homepages
- Use ProductCard with Astro Image and localized links

## Testing
- `npm run dev` *(fails: sh: 1: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0b9e16108330b0a15b8a409dfda0