### PR TITLE
Add FAQ, contact, and legal pages with contact block

### DIFF
--- a/limitedcharm-site/src/components/ContactBlock.astro
+++ b/limitedcharm-site/src/components/ContactBlock.astro
@@ -2,11 +2,41 @@
 import { getDictionary } from '../i18n/dict';
 import type { Lang } from '../i18n/config';
 
-interface Props { lang: Lang; }
+interface Props { lang: Lang }
 const dict = getDictionary(Astro.props.lang) ?? {};
-const contact = dict?.contact ?? { heading: '' };
+const contact = dict?.contact ?? {
+  heading: 'Contact',
+  address: '123 Main St, City',
+  phone: '+1 234 567 890',
+  email: 'info@example.com'
+};
 ---
-<section class="p-8">
-<h2 class="text-xl font-bold">{contact?.heading ?? ''}</h2>
-  <p>email@example.com</p>
+<section class="p-8" aria-labelledby="contact-heading">
+  <h2 id="contact-heading" class="text-xl font-bold mb-4">{contact?.heading ?? 'Contact'}</h2>
+  <address class="not-italic mb-4">
+    {contact?.address ?? '123 Main St, City'}
+    <br />
+    <a href={`tel:${contact?.phone ?? ''}`} class="block min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+      {contact?.phone ?? '+1 234 567 890'}
+    </a>
+    <a href={`mailto:${contact?.email ?? 'info@example.com'}`} class="block min-h-[44px] min-w-[44px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2">
+      {contact?.email ?? 'info@example.com'}
+    </a>
+  </address>
+  <form action="https://formspree.io/f/placeholder" method="POST" class="space-y-4">
+    <div>
+      <label for="name" class="block mb-1">Name</label>
+      <input id="name" name="name" type="text" required class="w-full border p-2" />
+    </div>
+    <div>
+      <label for="email" class="block mb-1">Email</label>
+      <input id="email" name="email" type="email" required class="w-full border p-2" />
+    </div>
+    <div>
+      <label for="message" class="block mb-1">Message</label>
+      <textarea id="message" name="message" required class="w-full border p-2"></textarea>
+    </div>
+    <button type="submit" class="px-4 py-2 border">Send</button>
+  </form>
 </section>
+

--- a/limitedcharm-site/src/i18n/dict.ts
+++ b/limitedcharm-site/src/i18n/dict.ts
@@ -5,8 +5,8 @@ export type SectionDict = {
   hero: { title: string; subtitle: string; cta: string };
   about: { heading: string; benefits: string[] };
   stats: { years: string; orders: string; satisfaction: string };
-  faq: { heading: string };
-  contact: { heading: string };
+  faq: { heading: string; items?: { question: string; answer: string }[] };
+  contact: { heading: string; address: string; phone: string; email: string };
   legal: { privacy: string; terms: string; shipping: string; disclaimer: string; complaint: string };
 };
 
@@ -24,7 +24,12 @@ export const dictionaries: Record<Lang, SectionDict> = {
     },
     stats: { years: 'Години на пазарот', orders: 'Извршени нарачки', satisfaction: 'Задоволство на клиенти' },
     faq: { heading: 'ЧПП' },
-    contact: { heading: 'Контакт' },
+    contact: {
+      heading: 'Контакт',
+      address: '123 Main St, City',
+      phone: '+1 234 567 890',
+      email: 'info@example.com'
+    },
     legal: { privacy: 'Приватност', terms: 'Услови', shipping: 'Испорака', disclaimer: 'Одговорност', complaint: 'Претставка' }
   },
   en: {
@@ -40,7 +45,12 @@ export const dictionaries: Record<Lang, SectionDict> = {
     },
     stats: { years: 'Years on market', orders: 'Orders processed', satisfaction: 'Customer satisfaction' },
     faq: { heading: 'FAQ' },
-    contact: { heading: 'Contact' },
+    contact: {
+      heading: 'Contact',
+      address: '123 Main St, City',
+      phone: '+1 234 567 890',
+      email: 'info@example.com'
+    },
     legal: { privacy: 'Privacy', terms: 'Terms', shipping: 'Shipping', disclaimer: 'Disclaimer', complaint: 'Complaint' }
   },
   sq: {
@@ -56,7 +66,12 @@ export const dictionaries: Record<Lang, SectionDict> = {
     },
     stats: { years: 'Vite në treg', orders: 'Porosi të kryera', satisfaction: 'Kënaqësi e klientëve' },
     faq: { heading: 'FAQ' },
-    contact: { heading: 'Kontakt' },
+    contact: {
+      heading: 'Kontakt',
+      address: '123 Main St, City',
+      phone: '+1 234 567 890',
+      email: 'info@example.com'
+    },
     legal: { privacy: 'Privatësia', terms: 'Kushtet', shipping: 'Dërgesa', disclaimer: 'Përgënjeshtrim', complaint: 'Ankesë' }
   }
 };

--- a/limitedcharm-site/src/pages/[lang]/complaint.astro
+++ b/limitedcharm-site/src/pages/[lang]/complaint.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 
 export function getStaticPaths() {
@@ -11,6 +12,12 @@ const { lang } = Astro.params;
 if (!isLang(lang)) {
   throw Astro.redirect(`/${DEFAULT_LANG}/`);
 }
+
+const dict = getDictionary(lang) ?? {};
+const title = dict?.legal?.complaint ?? 'Complaint';
 ---
-<BaseLayout lang={lang} title="Complaint" description="">
+<BaseLayout lang={lang} title={title} description="">
+  <h1 class="text-2xl font-bold mb-4">{title}</h1>
+  <p>Placeholder complaint content.</p>
 </BaseLayout>
+

--- a/limitedcharm-site/src/pages/[lang]/contact.astro
+++ b/limitedcharm-site/src/pages/[lang]/contact.astro
@@ -1,5 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import ContactBlock from '../../components/ContactBlock.astro';
+import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 
 export function getStaticPaths() {
@@ -11,6 +13,12 @@ const { lang } = Astro.params;
 if (!isLang(lang)) {
   throw Astro.redirect(`/${DEFAULT_LANG}/`);
 }
+
+const dict = getDictionary(lang) ?? {};
+const title = dict?.contact?.heading ?? 'Contact';
 ---
-<BaseLayout lang={lang} title="Contact" description="">
+<BaseLayout lang={lang} title={title} description="">
+  <h1 class="text-2xl font-bold mb-6">{title}</h1>
+  <ContactBlock lang={lang} />
 </BaseLayout>
+

--- a/limitedcharm-site/src/pages/[lang]/disclaimer.astro
+++ b/limitedcharm-site/src/pages/[lang]/disclaimer.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 
 export function getStaticPaths() {
@@ -11,6 +12,12 @@ const { lang } = Astro.params;
 if (!isLang(lang)) {
   throw Astro.redirect(`/${DEFAULT_LANG}/`);
 }
+
+const dict = getDictionary(lang) ?? {};
+const title = dict?.legal?.disclaimer ?? 'Disclaimer';
 ---
-<BaseLayout lang={lang} title="Disclaimer" description="">
+<BaseLayout lang={lang} title={title} description="">
+  <h1 class="text-2xl font-bold mb-4">{title}</h1>
+  <p>Placeholder disclaimer content.</p>
 </BaseLayout>
+

--- a/limitedcharm-site/src/pages/[lang]/faq.astro
+++ b/limitedcharm-site/src/pages/[lang]/faq.astro
@@ -1,5 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import FAQ from '../../components/FAQ.astro';
+import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 
 export function getStaticPaths() {
@@ -11,6 +13,20 @@ const { lang } = Astro.params;
 if (!isLang(lang)) {
   throw Astro.redirect(`/${DEFAULT_LANG}/`);
 }
+
+const dict = getDictionary(lang) ?? {};
+const title = dict?.faq?.heading ?? 'FAQ';
+const items = dict?.faq?.items ?? [
+  { question: 'Question 1?', answer: 'Answer 1.' },
+  { question: 'Question 2?', answer: 'Answer 2.' },
+  { question: 'Question 3?', answer: 'Answer 3.' },
+  { question: 'Question 4?', answer: 'Answer 4.' },
+  { question: 'Question 5?', answer: 'Answer 5.' },
+  { question: 'Question 6?', answer: 'Answer 6.' }
+];
 ---
-<BaseLayout lang={lang} title="Faq" description="">
+<BaseLayout lang={lang} title={title} description="">
+  <h1 class="text-2xl font-bold mb-6">{title}</h1>
+  <FAQ items={items} />
 </BaseLayout>
+

--- a/limitedcharm-site/src/pages/[lang]/index.astro
+++ b/limitedcharm-site/src/pages/[lang]/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Hero from '../../components/Hero.astro';
 import ProductCard from '../../components/ProductCard.astro';
 import Stats from '../../components/Stats.astro';
+import ContactBlock from '../../components/ContactBlock.astro';
 import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 import product1 from '../../content/products/product-1.mdx';
@@ -69,4 +70,7 @@ const stats = [
 
   <!-- Stats Section -->
   <Stats stats={stats} />
+
+  <!-- Contact Section -->
+  <ContactBlock lang={lang} />
 </BaseLayout>

--- a/limitedcharm-site/src/pages/[lang]/privacy.astro
+++ b/limitedcharm-site/src/pages/[lang]/privacy.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 
 export function getStaticPaths() {
@@ -11,6 +12,12 @@ const { lang } = Astro.params;
 if (!isLang(lang)) {
   throw Astro.redirect(`/${DEFAULT_LANG}/`);
 }
+
+const dict = getDictionary(lang) ?? {};
+const title = dict?.legal?.privacy ?? 'Privacy';
 ---
-<BaseLayout lang={lang} title="Privacy" description="">
+<BaseLayout lang={lang} title={title} description="">
+  <h1 class="text-2xl font-bold mb-4">{title}</h1>
+  <p>Placeholder privacy content.</p>
 </BaseLayout>
+

--- a/limitedcharm-site/src/pages/[lang]/shipping.astro
+++ b/limitedcharm-site/src/pages/[lang]/shipping.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 
 export function getStaticPaths() {
@@ -11,6 +12,12 @@ const { lang } = Astro.params;
 if (!isLang(lang)) {
   throw Astro.redirect(`/${DEFAULT_LANG}/`);
 }
+
+const dict = getDictionary(lang) ?? {};
+const title = dict?.legal?.shipping ?? 'Shipping';
 ---
-<BaseLayout lang={lang} title="Shipping" description="">
+<BaseLayout lang={lang} title={title} description="">
+  <h1 class="text-2xl font-bold mb-4">{title}</h1>
+  <p>Placeholder shipping content.</p>
 </BaseLayout>
+

--- a/limitedcharm-site/src/pages/[lang]/terms.astro
+++ b/limitedcharm-site/src/pages/[lang]/terms.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getDictionary } from '../../i18n/dict';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../i18n/config';
 
 export function getStaticPaths() {
@@ -11,6 +12,12 @@ const { lang } = Astro.params;
 if (!isLang(lang)) {
   throw Astro.redirect(`/${DEFAULT_LANG}/`);
 }
+
+const dict = getDictionary(lang) ?? {};
+const title = dict?.legal?.terms ?? 'Terms';
 ---
-<BaseLayout lang={lang} title="Terms" description="">
+<BaseLayout lang={lang} title={title} description="">
+  <h1 class="text-2xl font-bold mb-4">{title}</h1>
+  <p>Placeholder terms content.</p>
 </BaseLayout>
+


### PR DESCRIPTION
## Summary
- add ContactBlock component with address, phone, email and Formspree form
- build FAQ, contact, and legal pages for each language with dictionary fallbacks
- extend dictionaries and render ContactBlock on home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b403e788330929d06d7e6add82b