### PR TITLE
Fix BaseLayout import paths and remove deprecated image plugin

### DIFF
--- a/limitedcharm-site/astro.config.mjs
+++ b/limitedcharm-site/astro.config.mjs
@@ -1,9 +1,8 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
-import image from '@astrojs/image';
 import mdx from '@astrojs/mdx';
 
 export default defineConfig({
   site: 'https://example.com',
-  integrations: [tailwind(), image(), mdx()],
+  integrations: [tailwind(), mdx()],
 });

--- a/limitedcharm-site/package-lock.json
+++ b/limitedcharm-site/package-lock.json
@@ -8,7 +8,6 @@
       "name": "limitedcharm-site",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/image": "^0.18.0",
         "@astrojs/mdx": "^4.3.3",
         "astro": "^5.13.0"
       },
@@ -43,30 +42,6 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.2.tgz",
       "integrity": "sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==",
       "license": "MIT"
-    },
-    "node_modules/@astrojs/image": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/image/-/image-0.18.0.tgz",
-      "integrity": "sha512-IAsECAGG5s0u7KItQMVVfhU8gAkIeIlzoSga6LymLvWvTWJacjxtnRYjct5uR03kuxIYAdjZhwQowKR1bYpwDA==",
-      "deprecated": "@astrojs/image is deprecated in favor of astro:assets. Please see the migration guide for more information: https://docs.astro.build/en/guides/upgrade-to/v3/\\#removed-astrojsimage",
-      "license": "MIT",
-      "dependencies": {
-        "@altano/tiny-async-pool": "^1.0.2",
-        "http-cache-semantics": "^4.1.1",
-        "image-size": "^1.0.2",
-        "kleur": "^4.1.5",
-        "magic-string": "^0.30.2",
-        "mime": "^3.0.0"
-      },
-      "peerDependencies": {
-        "astro": "^2.10.15",
-        "sharp": ">=0.31.0"
-      },
-      "peerDependenciesMeta": {
-        "sharp": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.7.1",

--- a/limitedcharm-site/package.json
+++ b/limitedcharm-site/package.json
@@ -9,7 +9,6 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "@astrojs/image": "^0.18.0",
     "@astrojs/mdx": "^4.3.3",
     "astro": "^5.13.0"
   },

--- a/limitedcharm-site/src/components/Hero.astro
+++ b/limitedcharm-site/src/components/Hero.astro
@@ -1,7 +1,6 @@
 ---
 import { getDictionary } from '../i18n/dict';
 import type { Lang } from '../i18n/config';
-import { Image } from '@astrojs/image/components';
 
 interface Props {
   lang: Lang;
@@ -14,7 +13,7 @@ const imageSrc = Astro.props.image ?? '/assets/fallback1.png';
 ---
 <section class="py-12 text-center">
   <div class="flex flex-col items-center gap-6">
-    <Image src={imageSrc} alt={hero?.title ?? ''} width={960} height={400} formats={["avif", "webp", "png"]} sizes="(max-width: 768px) 100vw, 960px" loading="lazy" class="rounded" />
+      <img src={imageSrc} alt={hero?.title ?? ''} width="960" height="400" loading="lazy" class="rounded" />
     <h1 class="text-4xl font-bold">{hero?.title ?? ''}</h1>
     <p class="max-w-2xl text-lg">{hero?.subtitle ?? ''}</p>
     <a href={`/${Astro.props.lang}/products`} class="mt-4 px-6 py-3 bg-blue-600 text-white rounded">{hero?.cta ?? 'More'}</a>

--- a/limitedcharm-site/src/components/ProductCard.astro
+++ b/limitedcharm-site/src/components/ProductCard.astro
@@ -1,6 +1,5 @@
 ---
 import type { Lang } from '../i18n/config';
-import { Image } from '@astrojs/image/components';
 
 interface Props {
   title?: string;
@@ -27,7 +26,7 @@ const {
 const imageSrc = image ?? '/assets/fallback1.png';
 ---
 <article class="border p-4 flex flex-col">
-  <Image src={imageSrc} alt={title} width={300} height={300} formats={["avif", "webp", "png"]} sizes="(max-width: 768px) 100vw, 300px" loading="lazy" class="mb-4 rounded" />
+  <img src={imageSrc} alt={title} width="300" height="300" loading="lazy" class="mb-4 rounded" />
   <h3 class="text-xl font-semibold mb-2">{title}</h3>
   {description && <p class="mb-2">{description}</p>}
   <p class="mb-4">{short}</p>

--- a/limitedcharm-site/src/pages/[lang]/products/[slug]/index.astro
+++ b/limitedcharm-site/src/pages/[lang]/products/[slug]/index.astro
@@ -1,8 +1,8 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../../i18n/config';
-import product1 from '../../../content/products/product-1.mdx';
-import product2 from '../../../content/products/product-2.mdx';
+import BaseLayout from '../../../../layouts/BaseLayout.astro';
+import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../../../i18n/config';
+import product1 from '../../../../content/products/product-1.mdx';
+import product2 from '../../../../content/products/product-2.mdx';
 
 const allProducts = [product1, product2].filter(Boolean);
 


### PR DESCRIPTION
## Summary
- fix incorrect relative paths to BaseLayout and content modules
- remove deprecated `@astrojs/image` integration and fallback to `<img>` tags

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)*
- `npm run build` *(fails: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1ed98e588330be702d67de792552