### PR TITLE
feat: optimize assets and performance

### DIFF
--- a/limitedcharm-site/_headers
+++ b/limitedcharm-site/_headers
@@ -1,0 +1,2 @@
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/limitedcharm-site/src/components/Header.astro
+++ b/limitedcharm-site/src/components/Header.astro
@@ -31,17 +31,17 @@ const suffix = path.replace(new RegExp(`^/${lang}`), '') || '/';
 
     <div class="flex items-center gap-2">
       <!-- Language switcher dropdown -->
-      <div class="relative" id="lang-switcher">
-        <button type="button" class="p-2 min-w-[44px] min-h-[44px] flex items-center justify-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" aria-haspopup="true" aria-expanded="false">
+      <details class="relative">
+        <summary class="list-none p-2 min-w-[44px] min-h-[44px] flex items-center justify-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2" aria-haspopup="true">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-6 w-6"><circle cx="12" cy="12" r="10" /><line x1="2" y1="12" x2="22" y2="12" /><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" /></svg>
           <span class="sr-only">Language</span>
-        </button>
-        <ul class="absolute right-0 mt-2 hidden bg-white shadow-lg rounded-md" role="menu">
+        </summary>
+        <ul class="absolute right-0 mt-2 bg-white shadow-lg rounded-md" role="menu">
           {SUPPORTED_LANGUAGES.map((l) => (
             <li><a href={`/${l}${suffix}`} class="block px-4 py-2 hover:bg-gray-100 focus:bg-gray-100" role="menuitem">{l.toUpperCase()}</a></li>
           ))}
         </ul>
-      </div>
+      </details>
 
       <!-- Mobile menu -->
       <details class="md:hidden">
@@ -65,32 +65,4 @@ const suffix = path.replace(new RegExp(`^/${lang}`), '') || '/';
       </details>
     </div>
   </div>
-</header>
-
-<script is:inline>
-  const switcher = document.getElementById('lang-switcher');
-  const button = switcher?.querySelector('button');
-  const menu = switcher?.querySelector('ul');
-  function closeMenu() {
-    menu?.classList.add('hidden');
-    button?.setAttribute('aria-expanded', 'false');
-  }
-  button?.addEventListener('click', (e) => {
-    e.stopPropagation();
-    const hidden = menu?.classList.contains('hidden');
-    if (hidden) {
-      menu?.classList.remove('hidden');
-      button?.setAttribute('aria-expanded', 'true');
-    } else {
-      closeMenu();
-    }
-  });
-  menu?.querySelectorAll('a').forEach((a) => {
-    a.addEventListener('click', () => closeMenu());
-  });
-  document.addEventListener('click', (e) => {
-    if (!switcher?.contains(e.target)) {
-      closeMenu();
-    }
-  });
-</script>
+ </header>

--- a/limitedcharm-site/src/components/Hero.astro
+++ b/limitedcharm-site/src/components/Hero.astro
@@ -1,19 +1,21 @@
 ---
 import { getDictionary } from '../i18n/dict';
 import type { Lang } from '../i18n/config';
+import { Image } from 'astro:assets';
+import fallbackImg from '../assets/fallback1.png';
 
 interface Props {
   lang: Lang;
-  image?: string;
+  image?: unknown;
 }
 
 const dict = getDictionary(Astro.props.lang) ?? {};
 const hero = dict?.hero ?? { title: '', subtitle: '', cta: '' };
-const imageSrc = Astro.props.image ?? '/assets/fallback1.png';
+const imageSrc = Astro.props.image ?? fallbackImg;
 ---
 <section class="py-12 text-center">
   <div class="flex flex-col items-center gap-6">
-      <img src={imageSrc} alt={hero?.title ?? ''} width="960" height="400" loading="lazy" class="rounded" />
+      <Image src={imageSrc} alt={hero?.title ?? ''} width={960} height={400} format={['avif','webp']} sizes="(max-width: 960px) 100vw, 960px" class="rounded" />
     <h1 class="text-4xl font-bold">{hero?.title ?? ''}</h1>
     <p class="max-w-2xl text-lg">{hero?.subtitle ?? ''}</p>
     <a href={`/${Astro.props.lang}/products`} class="mt-4 px-6 py-3 bg-blue-600 text-white rounded">{hero?.cta ?? 'More'}</a>

--- a/limitedcharm-site/src/components/ProductCard.astro
+++ b/limitedcharm-site/src/components/ProductCard.astro
@@ -1,10 +1,12 @@
 ---
 import type { Lang } from '../i18n/config';
+import { Image } from 'astro:assets';
+import fallbackImg from '../assets/fallback1.png';
 
 interface Props {
   title?: string;
   description?: string;
-  image?: string;
+  image?: unknown;
   short?: string;
   price?: string;
   price_old?: string;
@@ -23,10 +25,10 @@ const {
   lang
 } = Astro.props as Props;
 
-const imageSrc = image ?? '/assets/fallback1.png';
+const imageSrc = image ?? fallbackImg;
 ---
 <article class="border p-4 flex flex-col">
-  <img src={imageSrc} alt={title} width="300" height="300" loading="lazy" class="mb-4 rounded" />
+  <Image src={imageSrc} alt={title} width={300} height={300} format={['avif','webp']} sizes="(max-width: 300px) 100vw, 300px" class="mb-4 rounded" />
   <h3 class="text-xl font-semibold mb-2">{title}</h3>
   {description && <p class="mb-2">{description}</p>}
   <p class="mb-4">{short}</p>

--- a/limitedcharm-site/src/content/products/product-2.mdx
+++ b/limitedcharm-site/src/content/products/product-2.mdx
@@ -3,7 +3,7 @@ title: "Natural Cream"
 description: "Second product"
 subtitle: "Soothing skin care"
 price: "18 €"
-image: "https://via.placeholder.com/300x300"
+image: "../../assets/product2.png"
 short: "Natural cream that soothes and nourishes."
 slug: "natural-cream"
 ---

--- a/limitedcharm-site/src/pages/[lang]/index.astro
+++ b/limitedcharm-site/src/pages/[lang]/index.astro
@@ -30,12 +30,14 @@ const dict = getDictionary(lang) ?? {};
 const rawProducts = [product1?.frontmatter, product2?.frontmatter].filter(Boolean);
 
 // Map products and ensure images are always defined
-const products = rawProducts.map((p, i) => ({
-  ...p,
-  image: p?.image
-    ? new URL(p.image, import.meta.url).pathname
-    : (i === 0 ? fallback1 : fallback2)
-}));
+const products = await Promise.all(
+  rawProducts.map(async (p, i) => ({
+    ...p,
+    image: p?.image
+      ? (await import(/* @vite-ignore */ p.image)).default
+      : (i === 0 ? fallback1 : fallback2)
+  }))
+);
 
 const stats = [
   { label: dict?.stats?.years ?? '', value: '5+' },

--- a/limitedcharm-site/src/pages/[lang]/products/[slug]/index.astro
+++ b/limitedcharm-site/src/pages/[lang]/products/[slug]/index.astro
@@ -3,6 +3,8 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import { SUPPORTED_LANGUAGES, DEFAULT_LANG, isLang } from '../../../../i18n/config';
 import product1 from '../../../../content/products/product-1.mdx';
 import product2 from '../../../../content/products/product-2.mdx';
+import { Image } from 'astro:assets';
+import fallbackImg from '../../../../assets/fallback1.png';
 
 const allProducts = [product1, product2].filter(Boolean);
 
@@ -26,10 +28,13 @@ if (!isLang(lang)) {
 }
 
 const { product = {}, Content } = Astro.props;
+const imageSrc = product.image
+  ? (await import(/* @vite-ignore */ new URL(product.image, new URL('../../../../content/products/', import.meta.url)).pathname)).default
+  : fallbackImg;
 ---
 <BaseLayout lang={lang} title={product?.title ?? ''} description={product?.description ?? ''}>
   <article class="max-w-3xl mx-auto py-12">
-    <img src={product?.image ?? '/assets/fallback1.png'} alt={product?.title ?? ''} width="600" height="600" class="mb-4 rounded" />
+    <Image src={imageSrc} alt={product?.title ?? ''} width={600} height={600} format={['avif','webp']} sizes="(max-width: 600px) 100vw, 600px" class="mb-4 rounded" />
     <h1 class="text-3xl font-bold mb-4">{product?.title ?? ''}</h1>
     <p class="mb-4">{product?.short ?? ''}</p>
     {Content ? <Content /> : null}

--- a/limitedcharm-site/src/styles/tailwind.css
+++ b/limitedcharm-site/src/styles/tailwind.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  }
+}


### PR DESCRIPTION
## Summary
- use system font stack globally
- replace img tags with Astro `<Image>` and preload AVIF/WebP
- remove client script and add example Netlify caching headers

## Testing
- `npm install` *(fails: E403 Forbidden - GET https://registry.npmjs.org/typescript)*

------
https://chatgpt.com/codex/tasks/task_e_689e21a7f82083308985063c33b12f16